### PR TITLE
Job and Parameter creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 set(COVERAGE "Coverage" ON)
-set(COMPILE_FLAGS -Wall -Werror -fsanitize=address -fsanitize=leak -pthread)
+set(COMPILE_FLAGS -Wall -Werror -fsanitize=address -fsanitize=leak -fno-omit-frame-pointer -pthread)
 set(LINK_FLAGS -fsanitize=address)
 
 #SET(GCC_WERR_COMPILE_FLAGS "-Wall -Werror")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-#set(COVERAGE "Coverage" ON)
+set(COVERAGE "Coverage" ON)
 set(COMPILE_FLAGS -Wall -Werror -fsanitize=address -fsanitize=leak -pthread)
 set(LINK_FLAGS -fsanitize=address)
 
@@ -21,7 +21,7 @@ set(LINK_FLAGS -fsanitize=address)
 find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIR})
 
-add_library(libwebqc SHARED src/libwebqc.c src/webqc-options.c src/webqc-errors.c src/web_access.c)
+add_library(libwebqc SHARED src/libwebqc.c src/webqc-options.c src/webqc-errors.c src/web_access.c src/reply_parsers.c include/webqc-json.h)
 
 target_compile_options(libwebqc PUBLIC ${COMPILE_FLAGS})
 target_link_options(libwebqc PUBLIC ${LINK_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-set(COVERAGE "Coverage" ON)
+#set(COVERAGE "Coverage" ON)
 set(COMPILE_FLAGS -Wall -Werror -fsanitize=address -fsanitize=leak -pthread)
 set(LINK_FLAGS -fsanitize=address)
 

--- a/MERGE-CHECKLIST.md
+++ b/MERGE-CHECKLIST.md
@@ -1,0 +1,51 @@
+*Code Quality Checks*
+
+- Abstraction Go down one abstraction level per function call
+- Multi step processes should be constructed in a way that makes it impossible to skip a step. For example, a read operation should only be available as a method of an object representing a successfully  opened-file.
+- Every logging line is marked by both module and level
+- Code has no side effects
+- only one exit point from a function
+- Initialize all variables
+- Wrap calls to libraries for easier replacement
+- All names in code (variables, functions, classes etc) are meaningful and used for what they are named for
+- Function length is maximum 20 lines
+- No more than one loop in a function
+- Functions have maximum of three parameters
+- Classes have few members and methods.
+- All functions that can fail return a return-code structure.
+- The code assumes that everything that can fail, will fail.
+- All REST and replies calls are logged in full details
+- All  input is checked for correctness
+- Code is fully Doxygen-ed
+- comment on what, not how.
+- If an object can be declared as const, make it const.
+- All code is covered with unit tests - 100% of code lines.
+
+
+*Design Compliance Checks*
+
+- All input data comes with:
+  - Error specification in %
+  - Units
+  - Data Lineage record
+- All output data is created with:
+  - Error specification in %
+  - Units
+  - Data Lineage Record
+- Error messages contain:
+  - What the software tried to do
+  - What went wrong
+  - How to remedy the problem
+  - As many relevant details as are at hand at the time the error occurred
+- Numbers are either integers or double-precision. Do not use single precision.
+- For anything that is not the novel core of the software, well-established external libraries with an appropriate license should always be used instead of writing new code.
+- All file formats should be well established cloud oriented format (eg JSON)
+- Heavy calculations are always checkpointed and restartable from a checkpoint
+- The user can always get the state of a heavy calculation so that they at  least have a general idea how long it has been running and how long it has to run, in both wall time and percentage completed.
+- All input, configuration, software versions and intermediary data is saved at the back end so that any calculation can be repeated exactly and produce the same result.
+
+*Development Process Checks*
+- All tests have passes
+- Code is 100% covered
+- Every Function or type or constand have a Doxygen documentation. Function 
+documentation includes what the function does, documentation of each parameter and of the return value

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # libwebqc
-C Interface library to the WebQC web service
+C Interface library to the WebQC web service.
 
 This library is intended to be a base for the C++ and Fortran interfaces. It does not do any computations - it calls the WebQC web service.
 

--- a/examples/water-sto3g-integrals.c
+++ b/examples/water-sto3g-integrals.c
@@ -86,8 +86,6 @@ main(int argc, const char *argv[])
 
     WQC *handler = wqc_init();
 
-    wqc_set_option(handler, WQC_OPTION_ACCESS_TOKEN, WQC_FREE_ACCESS_TOKEN);
-
     bool rv = calculate_integrals(handler);
 
     if ( rv ) {

--- a/examples/water-sto3g-integrals.c
+++ b/examples/water-sto3g-integrals.c
@@ -82,7 +82,8 @@ main(int argc, const char *argv[])
     verify_arguments(argc, argv);
     const char *output_filename = argv[1];
 
-    curl_global_init(0);
+    wqc_global_init();
+
     WQC *handler = wqc_init();
 
     wqc_set_option(handler, WQC_OPTION_ACCESS_TOKEN, WQC_FREE_ACCESS_TOKEN);
@@ -94,7 +95,7 @@ main(int argc, const char *argv[])
     }
     wqc_cleanup(handler);
 
-    curl_global_cleanup();
+    wqc_global_cleanup();
 
     return 0;
 }

--- a/examples/water-sto3g-integrals.c
+++ b/examples/water-sto3g-integrals.c
@@ -38,7 +38,7 @@ calculate_integrals(WQC *job_handler)
 
     bool res = wqc_submit_job(
             job_handler,
-            TWO_ELECTRONS_INTEGRAL,
+            WQC_JOB_TWO_ELECTRONS_INTEGRALS,
             &parameters
     ) ;
 

--- a/include/webqc-curl.h
+++ b/include/webqc-curl.h
@@ -36,3 +36,26 @@ bool set_eri_job_parameters(
     const struct two_electron_integrals_job_parameters *job_parameters
 );
 
+/// A name-value pair for adding multiple JSON fields at once
+struct name_value_pair {
+    const char *name; /// field name
+    enum wqc_data_type type; /// field type
+    union /// fill one of the three options below
+    {
+        const char *str_value;
+        wqc_real real_value;
+        int64_t int_value;
+    } value;
+};
+
+//! Set up HTTP POST fields on a handler
+//! \param handler which handler to set the POST fields on
+//! \param values fields to set, array of struct name_value_pair
+//! \param num_values how many members in the array of fields to add
+//! \return trur on success, false on failure (and sets error on the handler)
+bool set_POST_fields(
+    WQC *handler,
+    struct name_value_pair values[],
+    size_t num_values
+);
+

--- a/include/webqc-curl.h
+++ b/include/webqc-curl.h
@@ -27,11 +27,18 @@ bool cleanup_curl(
 );
 
 
-//! Configure the handler with parameter to calculate the Electron Repulsion Integrals (ERI)
+//! Generate the parameters for calculating the Electron Repulsion Integrals (ERI).
 //! \param handler handler that call will be make on
 //! \param job_parameters Details of the ERI calculation desired
 //! \return true on success, false on failure
-bool make_eri_request(
+bool set_eri_job_parameters(
     WQC *handler,
     const struct two_electron_integrals_job_parameters *job_parameters
+);
+
+//! Get the job ID from the most recent call to the WebQC API
+//! \param handler handler the call was made on
+//! \return true if the job id was found. The job ID is saved in the handler.
+bool get_job_id_from_reply(
+        WQC *handler
 );

--- a/include/webqc-curl.h
+++ b/include/webqc-curl.h
@@ -36,16 +36,3 @@ bool set_eri_job_parameters(
     const struct two_electron_integrals_job_parameters *job_parameters
 );
 
-//! Get the job ID from the most recent call to the WebQC API
-//! \param handler handler the call was made on
-//! \return true if the job id was found. The job ID is saved in the handler.
-bool get_job_id_from_reply(
-        WQC *handler
-);
-
-//! Get a parameter set ID from the most recent call to the WebQC API
-//! \param handler handler the call was made on
-//! \return true if the job id was found. The set ID is saved in the handler.
-bool get_parameter_set_id_from_reply(
-        WQC *handler
-);

--- a/include/webqc-curl.h
+++ b/include/webqc-curl.h
@@ -14,7 +14,7 @@ bool prepare_curl(
 
 //! Perform the call to the WebQC server.
 //! \param handler handler to make the call on
-//! \return true on success, false on failure. Success means the call was successful in getting some reply
+//! \return true on success, false on failure. Success means the call was successful in getting a 2XX HTTP reply
 bool make_curl_call(
     WQC *handler
 );

--- a/include/webqc-curl.h
+++ b/include/webqc-curl.h
@@ -42,3 +42,10 @@ bool set_eri_job_parameters(
 bool get_job_id_from_reply(
         WQC *handler
 );
+
+//! Get a parameter set ID from the most recent call to the WebQC API
+//! \param handler handler the call was made on
+//! \return true if the job id was found. The set ID is saved in the handler.
+bool get_parameter_set_id_from_reply(
+        WQC *handler
+);

--- a/include/webqc-errors.h
+++ b/include/webqc-errors.h
@@ -28,14 +28,3 @@ struct wqc_return_value {
         const char *func;///< Function name where error occurred
 } ;
 
-//! @brief Initialize variables of type  webqc_return_value_t.
-//! \return empty webqc_return_value_t.
-struct wqc_return_value init_webqc_return_value();
-
-//! @brief return the error message associated with the error code
-//! \param error_code error code
-//! \return read-only string that contains the corresponding error message
-const char *
-wqc_get_error_by_code(
-        error_code_t error_code
-);

--- a/include/webqc-errors.h
+++ b/include/webqc-errors.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 
-#define MAX_WEBQC_ERROR_MESSAGE_LEN (256) ///< Maximum size of error message in webqc_return_value_t;
+#define MAX_WEBQC_ERROR_MESSAGE_LEN (1024) ///< Maximum size of error message in webqc_return_value_t;
 
 #define WEBQC_SUCCESS (0) ///< Call was successful
 #define WEBQC_ERROR_UNKNOWN_OPTION (1) ///< An unknown option was passed to the API

--- a/include/webqc-handler.h
+++ b/include/webqc-handler.h
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "webqc-errors.h"
+#include "../libwebqc.h"
 #include <curl/curl.h>
 
 #ifdef __cplusplus
@@ -47,6 +48,7 @@ struct webqc_handler_t {
     char job_id[WQC_JOB_ID_LENGTH]; /// Job ID the handler is currently doing
     char parameter_set_id[WQC_PARAM_SET_ID_LENGTH]; /// Job ID the handler is currently doing
     const char *wqc_endpoint; /// Which WebQC endpoint to call
+    enum wqc_job_type job_type; /// What is the job type this handler is calling for
 };
 
 //! Add reply data received from the web service to a reply buffer

--- a/include/webqc-handler.h
+++ b/include/webqc-handler.h
@@ -38,7 +38,6 @@ struct handler_curl_info
  * @brief Internal structure that maintains the status of an asynchrounous WQC operation.
  */
 struct webqc_handler_t {
-    uint64_t handler_id; /// A unique ID for this operation
     struct wqc_return_value return_value; /// Return value from last call to WQC API
     char *access_token; /// Token that authorizes access to the WEBQC web service
     struct handler_curl_info curl_info; /// Info for calling web services using libCURL
@@ -49,6 +48,7 @@ struct webqc_handler_t {
     char parameter_set_id[WQC_PARAM_SET_ID_LENGTH]; /// Job ID the handler is currently doing
     const char *wqc_endpoint; /// Which WebQC endpoint to call
     enum wqc_job_type job_type; /// What is the job type this handler is calling for
+    bool is_duplicate; /// Job was found to be a duplicate of another one
 };
 
 //! Add reply data received from the web service to a reply buffer

--- a/include/webqc-handler.h
+++ b/include/webqc-handler.h
@@ -5,7 +5,9 @@
 #include <curl/curl.h>
 
 #define MAX_URL_SIZE (1024) /// Maximum URL size
-#define WQC_JOB_ID_LENGTH (37) /// Job IDs are UUID - 32 bytes for hex + 4 dash + terminating null
+#define UUID_LENGTH (37) /// UUID - 32 bytes for hex + 4 dash + terminating null
+#define WQC_JOB_ID_LENGTH (UUID_LENGTH) /// Job IDs are UUIDs
+#define WQC_PARAM_SET_ID_LENGTH (UUID_LENGTH) /// Parameter set IDs are UUIDs
 
 //! Structure to hold a reply from a cURL call
 struct web_reply_buffer {
@@ -39,4 +41,6 @@ struct webqc_handler_t {
     unsigned short webqc_server_port; /// Port of the WebQC server
     bool insecure_ssl; /// Do not verify SSL certificates
     char job_id[WQC_JOB_ID_LENGTH]; /// Job ID the handler is currently doing
+    char parameter_set_id[WQC_PARAM_SET_ID_LENGTH]; /// Job ID the handler is currently doing
+
 };

--- a/include/webqc-handler.h
+++ b/include/webqc-handler.h
@@ -4,13 +4,18 @@
 #include "webqc-errors.h"
 #include <curl/curl.h>
 
-#define MAX_URL_SIZE 1024
+#define MAX_URL_SIZE (1024) /// Maximum URL size
+#define WQC_JOB_ID_LENGTH (37) /// Job IDs are UUID - 32 bytes for hex + 4 dash + terminating null
 
+//! Structure to hold a reply from a cURL call
 struct web_reply_buffer {
-    char *reply;
-    size_t size;
+    char *reply; /// Reply data
+    size_t size; /// Maximum length that can be stored in the "reply" buffer above
 };
 
+/**
+ * The cURL-library related part of the data saved per handler.
+ */
 struct handler_curl_info
 {
     CURL *curl_handler; /// current CURL call handler
@@ -33,4 +38,5 @@ struct webqc_handler_t {
     char *webqc_server_name; /// WebQC server name
     unsigned short webqc_server_port; /// Port of the WebQC server
     bool insecure_ssl; /// Do not verify SSL certificates
+    char job_id[WQC_JOB_ID_LENGTH]; /// Job ID the handler is currently doing
 };

--- a/include/webqc-handler.h
+++ b/include/webqc-handler.h
@@ -4,6 +4,10 @@
 #include "webqc-errors.h"
 #include <curl/curl.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MAX_URL_SIZE (1024) /// Maximum URL size
 #define UUID_LENGTH (37) /// UUID - 32 bytes for hex + 4 dash + terminating null
 #define WQC_JOB_ID_LENGTH (UUID_LENGTH) /// Job IDs are UUIDs
@@ -42,5 +46,21 @@ struct webqc_handler_t {
     bool insecure_ssl; /// Do not verify SSL certificates
     char job_id[WQC_JOB_ID_LENGTH]; /// Job ID the handler is currently doing
     char parameter_set_id[WQC_PARAM_SET_ID_LENGTH]; /// Job ID the handler is currently doing
-
+    const char *wqc_endpoint; /// Which WebQC endpoint to call
 };
+
+//! Add reply data received from the web service to a reply buffer
+//! \param data data recieved
+//! \param total_size total size of data recieved (in bytes)
+//! \param buf reply buffer to add to
+//! \return number of bytes added
+size_t wqc_collect_downloaded_data
+(
+    void *data,
+    size_t total_size,
+    struct web_reply_buffer *buf
+);
+
+#ifdef __cplusplus
+} // "extern C"
+#endif

--- a/include/webqc-json.h
+++ b/include/webqc-json.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <stdbool.h>
+#include <cjson/cJSON.h>
+#include "../libwebqc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//! Get the job ID from the most recent call to the WebQC API
+//! \param handler handler the call was made on
+//! \return true if the job id was found. The job ID is saved in the handler.
+bool get_job_id_from_reply(
+        WQC *handler
+);
+
+//! Get a parameter set ID from the most recent call to the WebQC API
+//! \param handler handler the call was made on
+//! \return true if the job id was found. The set ID is saved in the handler.
+bool get_parameter_set_id_from_reply(
+        WQC *handler
+);
+
+//! Parse a WEB API JSON text reply into a cJSON structure.
+//! \param handler handler where we recieved the reply
+//! \param reply_json if JSON is parsed successfully, a cJSON handler. Caller must release memory with cJSON_Delete.
+//! \return true on success, false on failure (and error set on the handler).
+bool parse_JSON_reply(
+    WQC *handler,
+    cJSON **reply_json
+);
+
+#ifdef __cplusplus
+} // "extern C"
+#endif

--- a/include/webqc-json.h
+++ b/include/webqc-json.h
@@ -30,6 +30,15 @@ bool parse_JSON_reply(
     cJSON **reply_json
 );
 
+
+//! Update the handler's detail after a job submission
+//! \param handler handelr on which an HTTP reply was just recieved
+//! \return true on success, false on failure (and error set on the handler).
+bool update_job_details(
+    WQC *handler
+);
+
+
 #ifdef __cplusplus
 } // "extern C"
 #endif

--- a/include/webqc-options.h
+++ b/include/webqc-options.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define WQC_FREE_ACCESS_TOKEN "webqc-free-access" /// This token can be used to access free services
+#define WQC_FREE_ACCESS_TOKEN "test-token" /// This token can be used to access free services
 
 /// List of all WQC handler options
 typedef enum wqc_option_type

--- a/libwebqc.h
+++ b/libwebqc.h
@@ -73,6 +73,16 @@ bool wqc_get_last_error(
         struct wqc_return_value *error_structure
 );
 
+
+//! Find if the handler was called to do a job is actually a duplicate of another job which computes the same
+//! calculation and is already done or running.
+//! \param handler Han
+//! \return
+bool wqc_job_is_duplicate(
+    WQC *handler /// Hanlder to check for submitting a duplicate job
+);
+
+
 /// @brief Parameters for a jobs that calculates the two-electrons repulsion integrals in the given
 /// basis set on the given geormtry. The Geometry is in XYZ format. Units can be "angstrom" , "SI" for
 /// picometers or "au" (atomic units).

--- a/libwebqc.h
+++ b/libwebqc.h
@@ -24,8 +24,8 @@ typedef double wqc_real;
 /// When sending data to the cloud service, use these constants to specify what type is each parameter
 enum wqc_data_type
 {
-    WQC_STRING_TYPE = 1, /// WebQC cloud call Parameter is a string
-    WQC_REAL_TYPE = 2 /// WebQC cloud call Parameter is a real number
+    WQC_STRING_TYPE = 1, /// WebQC cloud call parameter is a string
+    WQC_REAL_TYPE = 2 /// WebQC cloud call parameter is a real number
 };
 
 typedef struct webqc_handler_t WQC; ///< A handler to a WQC operation. When starting an asynchronous job, a WQC is returned to the caller.

--- a/libwebqc.h
+++ b/libwebqc.h
@@ -12,8 +12,8 @@ extern "C" {
 
 typedef double wqc_real;
 
-#define DEFAULT_WEBQC_SERVER_NAME "cloudcompchem.ca"
-#define DEFAULT_WEBQC_SERVER_PORT (443)
+#define DEFAULT_WEBQC_SERVER_NAME "webqc.urysegal.com"
+#define DEFAULT_WEBQC_SERVER_PORT (5000)
 
 
 #define WQC_PRECISION_UNKNOWN ((wqc_real)0.0)  /// A number is of unknown precision
@@ -25,16 +25,17 @@ typedef double wqc_real;
 enum wqc_data_type
 {
     WQC_STRING_TYPE = 1, /// WebQC cloud call Parameter is a string
-    WQC_REAL_TYPE = 2, /// WebQC cloud call Parameter is a real number
-    WQC_INTEGER_TYPE = 3 /// WebQC cloud call Parameter is an integer
+    WQC_REAL_TYPE = 2 /// WebQC cloud call Parameter is a real number
 };
 
 typedef struct webqc_handler_t WQC; ///< A handler to a WQC operation. When starting an asynchronous job, a WQC is returned to the caller.
 
 /// List of all the possible calls to WecQC service
-typedef enum wqc_job_types_tag {
-    TWO_ELECTRONS_INTEGRAL = 1 /// Calculate all two-electrons repulsion integrals
-} wqc_job_type;
+enum wqc_job_type {
+    WQC_JOB_NEW_JOB = 1, /// Create a new generic job
+    WQC_JOB_SET_PARAMETERS = 2, /// Set parameters for a job
+    WQC_JOB_TWO_ELECTRONS_INTEGRALS = 3 /// Calculate all two-electrons repulsion integrals
+};
 
 
 //! Initialize a new job handler. You must call wqc_cleanup when the job is done and you do not need any more information
@@ -67,18 +68,19 @@ struct two_electron_integrals_job_parameters {
 } ;
 
 
-/// Submit an asynchronous job to the WQC server. It is not alowed to submit two jobs on the same handler without
-/// calling wqc_reset on the handler first.
+/// Submit an asynchronous job to the WQC server. It is not allowed to submit two jobs on the same handler without
+/// calling wqc_reset on the handler first. This call will create a new job, set the parameters on it, and launch the
+/// job.
 /// \param handler Handler to submit the job on, created by wqc_init()
 /// \param job_type Which type of job to perform
 /// \param job_parameters Parameters for the job
 /// \return true on successful submission of the job, false otherwise
 bool wqc_submit_job
-        (
-                WQC *handler,
-                wqc_job_type job_type,
-                void *job_parameters
-        );
+(
+    WQC *handler,
+    enum wqc_job_type job_type,
+    void *job_parameters
+);
 
 
 /// Get a reply for the given job. If result is not yet ready, wait for it.

--- a/libwebqc.h
+++ b/libwebqc.h
@@ -37,6 +37,13 @@ enum wqc_job_type {
     WQC_JOB_TWO_ELECTRONS_INTEGRALS = 3 /// Calculate all two-electrons repulsion integrals
 };
 
+//! Initialize the WQC library. Call once before calling any thing WQC functions.
+void wqc_global_init();
+
+//! Cleanip WQC library. Call one after finishing all calls to WQC functions.
+void wqc_global_cleanup();
+
+
 
 //! Initialize a new job handler. You must call wqc_cleanup when the job is done and you do not need any more information
 //! about it.
@@ -46,6 +53,10 @@ WQC *wqc_init();
 /// Cleanup a handler when you are done with it.
 /// \param handler the handler to cleanup and dispoose
 void wqc_cleanup(WQC *handler);
+
+/// Reset a handler so we can make another call with same access parameters
+/// \param handler the handler to reset
+void wqc_reset(WQC *handler);
 
 
 //! Return the error occured on the most recent API call using the givern handler

--- a/libwebqc.h
+++ b/libwebqc.h
@@ -10,6 +10,10 @@ extern "C" {
 #include "include/webqc-options.h"
 
 
+#define TWO_ELECTRONS_INTEGRAL_SERVICE_ENDPOINT "eri"
+#define NEW_JOB_SERVICE_ENDPOINT "job"
+#define PARAMETERS_SERVICE_ENDPOINT "params"
+
 typedef double wqc_real;
 
 #define DEFAULT_WEBQC_SERVER_NAME "webqc.urysegal.com"
@@ -144,6 +148,18 @@ void wqc_set_error_with_messages(
         WQC *handler,
         error_code_t code,
         const char *extra_messages[]
+);
+
+//! @brief Initialize variables of type  webqc_return_value_t.
+//! \return empty webqc_return_value_t.
+struct wqc_return_value init_webqc_return_value();
+
+//! @brief return the error message associated with the error code
+//! \param error_code error code
+//! \return read-only string that contains the corresponding error message
+const char *
+wqc_get_error_by_code(
+        error_code_t error_code
 );
 
 

--- a/libwebqc.h
+++ b/libwebqc.h
@@ -36,6 +36,7 @@ typedef struct webqc_handler_t WQC; ///< A handler to a WQC operation. When star
 
 /// List of all the possible calls to WecQC service
 enum wqc_job_type {
+    WQC_NULL_JOB = 0, /// Bad job type to specify unset value
     WQC_JOB_NEW_JOB = 1, /// Create a new generic job
     WQC_JOB_SET_PARAMETERS = 2, /// Set parameters for a job
     WQC_JOB_TWO_ELECTRONS_INTEGRALS = 3 /// Calculate all two-electrons repulsion integrals
@@ -137,6 +138,17 @@ bool wqc_get_option(
 void wqc_set_error(
         WQC *handler,
         error_code_t code
+);
+
+//! Set the error code on the handler. Error message is also set automatically, plus an
+//! additional message
+//! \param handler  Handler to set the error on
+//! \param code the error code to set
+//! \param extra_message NULL-terminated message
+void wqc_set_error_with_message(
+        WQC *handler,
+        error_code_t code,
+        const char *extra_messages
 );
 
 //! Set the error code on the handler. Error message is also set automatically, plus a NULL-terminated array

--- a/src/libwebqc.c
+++ b/src/libwebqc.c
@@ -81,11 +81,19 @@ void wqc_cleanup(WQC *handler)
 }
 
 
-static bool perform_REST_API_call(WQC *handler, const char *endpoint)
+static bool start_wqc_job(WQC *handler)
 {
     bool rv = false;
 
-    rv = prepare_curl(handler, endpoint);
+    rv = prepare_curl(handler, handler->wqc_endpoint);
+
+    if ( rv ) {
+        struct name_value_pair start_job_parameters[] = {
+                {"job_id",     WQC_STRING_TYPE, {.str_value=handler->job_id}},
+                {"parameter_set_id",   WQC_STRING_TYPE, {.str_value=handler->parameter_set_id}}
+        };
+        rv = set_POST_fields(handler, start_job_parameters, ARRAY_SIZE(start_job_parameters));
+    }
 
     if ( rv ) {
         rv = make_curl_call(handler);
@@ -164,7 +172,7 @@ bool wqc_submit_job(WQC *handler, enum wqc_job_type job_type, void *job_paramete
     }
 
     if ( rv ) {
-        rv = perform_REST_API_call(handler, handler->wqc_endpoint);
+        rv = start_wqc_job(handler);
     }
 
     return rv ;

--- a/src/libwebqc.c
+++ b/src/libwebqc.c
@@ -37,6 +37,7 @@ WQC *wqc_init()
     handler->job_id[0] = '\0';
     handler->wqc_endpoint = NULL;
     handler->job_type = WQC_NULL_JOB;
+    handler->is_duplicate = false;
 
     handler->curl_info.curl_handler = NULL;
     handler->curl_info.full_URL[0] = '\0';
@@ -81,10 +82,16 @@ void wqc_cleanup(WQC *handler)
     }
 }
 
+bool wqc_job_is_duplicate(WQC *handler)
+{
+    return handler->is_duplicate;
+}
 
 static bool start_wqc_job(WQC *handler)
 {
     bool rv = false;
+
+    handler->is_duplicate = false;
 
     rv = prepare_curl(handler, handler->wqc_endpoint);
 

--- a/src/libwebqc.c
+++ b/src/libwebqc.c
@@ -57,7 +57,6 @@ void wqc_reset(WQC *handler)
             handler->curl_info.web_reply.reply = NULL;
             handler->curl_info.web_reply.size=0;
         }
-        handler->return_value = init_webqc_return_value();
         handler->curl_info.http_reply_code = 0;
         handler->wqc_endpoint = NULL;
         handler->job_type = WQC_NULL_JOB;
@@ -102,7 +101,7 @@ static bool start_wqc_job(WQC *handler)
     }
 
     if (rv) {
-        update_job_details(handler);
+        rv = update_job_details(handler);
         wqc_reset(handler);
     }
     cleanup_curl(handler);
@@ -138,7 +137,6 @@ static bool wqc_create_parameter_set(WQC *handler, enum wqc_job_type job_type, v
     bool rv = false;
     const char *endpoint = NULL;
 
-    handler->job_type = job_type;
 
     rv = prepare_curl(handler, PARAMETERS_SERVICE_ENDPOINT);
 
@@ -160,6 +158,7 @@ static bool wqc_create_parameter_set(WQC *handler, enum wqc_job_type job_type, v
             get_parameter_set_id_from_reply(handler);
             wqc_reset(handler);
             handler->wqc_endpoint = endpoint;
+            handler->job_type = job_type;
         }
     }
 

--- a/src/libwebqc.c
+++ b/src/libwebqc.c
@@ -32,7 +32,7 @@ WQC *wqc_init()
 {
     WQC *handler = malloc(sizeof(struct webqc_handler_t));
     handler->return_value = init_webqc_return_value();
-    handler->access_token = NULL;
+    handler->access_token = strdup(WQC_FREE_ACCESS_TOKEN);
     handler->webqc_server_name = strdup(DEFAULT_WEBQC_SERVER_NAME);
     handler->webqc_server_port = DEFAULT_WEBQC_SERVER_PORT;
     handler->insecure_ssl = false;
@@ -56,6 +56,13 @@ void wqc_cleanup(WQC *handler)
             free(handler->access_token);
             handler->access_token = NULL;
         }
+
+        if (handler->curl_info.web_reply.reply) {
+            free(handler->curl_info.web_reply.reply);
+            handler->curl_info.web_reply.reply = NULL;
+            handler->curl_info.web_reply.size=0;
+        }
+
         free(handler->webqc_server_name);
         cleanup_curl(handler);
         free(handler);
@@ -86,7 +93,8 @@ static bool create_new_job(WQC *handler)
     rv = prepare_curl(handler, NEW_JOB_SERVICE_ENDPOINT);
 
     if ( rv ) {
-        curl_easy_setopt(handler->curl_info.curl_handler, CURLOPT_PUT, 1L);
+        curl_easy_setopt(handler->curl_info.curl_handler, CURLOPT_POST, 1L);
+        curl_easy_setopt(handler->curl_info.curl_handler, CURLOPT_POSTFIELDS, "{}");
         rv = make_curl_call(handler);
 
         if ( rv ) {

--- a/src/libwebqc.c
+++ b/src/libwebqc.c
@@ -36,6 +36,7 @@ WQC *wqc_init()
     handler->insecure_ssl = false;
     handler->job_id[0] = '\0';
     handler->wqc_endpoint = NULL;
+    handler->job_type = WQC_NULL_JOB;
 
     handler->curl_info.curl_handler = NULL;
     handler->curl_info.full_URL[0] = '\0';
@@ -59,6 +60,7 @@ void wqc_reset(WQC *handler)
         handler->return_value = init_webqc_return_value();
         handler->curl_info.http_reply_code = 0;
         handler->wqc_endpoint = NULL;
+        handler->job_type = WQC_NULL_JOB;
         cleanup_curl(handler);
     }
 }
@@ -99,6 +101,10 @@ static bool start_wqc_job(WQC *handler)
         rv = make_curl_call(handler);
     }
 
+    if (rv) {
+        update_job_details(handler);
+        wqc_reset(handler);
+    }
     cleanup_curl(handler);
 
     return rv;
@@ -131,6 +137,8 @@ static bool wqc_create_parameter_set(WQC *handler, enum wqc_job_type job_type, v
 {
     bool rv = false;
     const char *endpoint = NULL;
+
+    handler->job_type = job_type;
 
     rv = prepare_curl(handler, PARAMETERS_SERVICE_ENDPOINT);
 

--- a/src/reply_parsers.c
+++ b/src/reply_parsers.c
@@ -24,6 +24,17 @@ bool get_string_from_reply(cJSON *json, const char *field_name, char *dest, unsi
     return rv;
 }
 
+bool get_object_from_reply(cJSON *json, const char *field_name, cJSON **obj)
+{
+    bool rv = false;
+    *obj = cJSON_GetObjectItemCaseSensitive(json, field_name);
+    if (*obj && cJSON_IsObject(*obj) ) {
+        rv = true;
+    }
+    return rv;
+}
+
+
 
 bool parse_JSON_reply(WQC *handler, cJSON **reply_json)
 {
@@ -81,4 +92,62 @@ bool get_parameter_set_id_from_reply(WQC *handler)
     return get_string_field_from_reply(handler, "set_id", handler->parameter_set_id, WQC_PARAM_SET_ID_LENGTH);
 }
 
+bool update_eri_job_details(WQC *handler)
+{
+    bool rv = false;
+    cJSON *reply_json = NULL;
+    cJSON *job_status = NULL;
 
+    rv = parse_JSON_reply(handler, &reply_json);
+
+    if ( rv ) {
+        rv = get_object_from_reply(reply_json, "job_status", &job_status);
+    }
+
+    char eri_job_id[WQC_JOB_ID_LENGTH];
+
+    if ( rv )
+    {
+        if ( ! (rv=get_string_field_from_reply(handler, "job_id", eri_job_id, WQC_JOB_ID_LENGTH) )) {
+            wqc_set_error_with_message(handler, WEBQC_WEB_CALL_ERROR, "Cannot find ERI job ID in reply");
+        }
+    }
+
+    if ( rv )
+    {
+        memcpy(handler->job_id, eri_job_id, WQC_JOB_ID_LENGTH);
+    }
+
+    return rv;
+
+}
+
+
+bool update_job_details(WQC *handler)
+{
+    bool rv = true;
+    char reply_job_id[WQC_JOB_ID_LENGTH];
+
+    rv=get_string_field_from_reply(handler, "job_id", reply_job_id, WQC_JOB_ID_LENGTH);
+
+    if ( rv && memcmp(handler->job_id, reply_job_id, WQC_JOB_ID_LENGTH)) {
+        const char *extra_messages[] = {"Job ID in call does not match Job ID in reply ", handler->job_id, " ", reply_job_id, NULL};
+        wqc_set_error_with_messages(handler, WEBQC_WEB_CALL_ERROR, extra_messages);
+        rv = false;
+    }
+
+    if ( rv ) {
+        switch (handler->job_type) {
+            case WQC_JOB_TWO_ELECTRONS_INTEGRALS:
+                rv = update_eri_job_details(handler);
+                break;
+            case WQC_NULL_JOB:
+            case WQC_JOB_NEW_JOB:
+            case WQC_JOB_SET_PARAMETERS:
+                wqc_set_error_with_message(handler, WEBQC_WEB_CALL_ERROR, "Internal Error - handling job run reply, but request was not to run a job");
+                rv = false;
+                break;
+        }
+    }
+    return rv;
+}

--- a/src/reply_parsers.c
+++ b/src/reply_parsers.c
@@ -13,7 +13,7 @@
 #include "../libwebqc.h"
 #include "../include/webqc-handler.h"
 
-bool get_string_from_reply(cJSON *json, const char *field_name, char *dest, unsigned int max_size)
+bool get_string_from_JSON(cJSON *json, const char *field_name, char *dest, unsigned int max_size)
 {
     bool rv = false;
     cJSON *job_id = cJSON_GetObjectItemCaseSensitive(json, field_name);
@@ -75,7 +75,7 @@ static bool get_string_field_from_reply(WQC *handler, const char *label, char *t
     rv = parse_JSON_reply(handler, &reply_json);
 
     if ( rv ) {
-        rv = get_string_from_reply(reply_json, label, target, target_len);
+        rv = get_string_from_JSON(reply_json, label, target, target_len);
         cJSON_Delete(reply_json);
     }
 
@@ -108,7 +108,7 @@ bool update_eri_job_details(WQC *handler)
 
     if ( rv )
     {
-        if ( ! (rv=get_string_field_from_reply(handler, "job_id", eri_job_id, WQC_JOB_ID_LENGTH) )) {
+        if ( ! (rv= get_string_from_JSON(job_status, "job_id", eri_job_id, WQC_JOB_ID_LENGTH) )) {
             wqc_set_error_with_message(handler, WEBQC_WEB_CALL_ERROR, "Cannot find ERI job ID in reply");
         }
     }

--- a/src/reply_parsers.c
+++ b/src/reply_parsers.c
@@ -115,6 +115,9 @@ bool update_eri_job_details(WQC *handler)
 
     if ( rv )
     {
+        if (strncmp(handler->job_id, eri_job_id, WQC_JOB_ID_LENGTH)) {
+            handler->is_duplicate = true;
+        }
         memcpy(handler->job_id, eri_job_id, WQC_JOB_ID_LENGTH);
     }
 

--- a/src/reply_parsers.c
+++ b/src/reply_parsers.c
@@ -118,6 +118,9 @@ bool update_eri_job_details(WQC *handler)
         memcpy(handler->job_id, eri_job_id, WQC_JOB_ID_LENGTH);
     }
 
+    if ( reply_json ) {
+        cJSON_Delete(reply_json);
+    }
     return rv;
 
 }

--- a/src/reply_parsers.c
+++ b/src/reply_parsers.c
@@ -1,0 +1,84 @@
+#include <string.h>
+#include <cjson/cJSON.h>
+
+#ifdef __APPLE__
+#include <malloc/malloc.h>
+#include <stdlib.h>
+#else
+
+#include <malloc.h>
+
+#endif
+
+#include "../libwebqc.h"
+#include "../include/webqc-handler.h"
+
+bool get_string_from_reply(cJSON *json, const char *field_name, char *dest, unsigned int max_size)
+{
+    bool rv = false;
+    cJSON *job_id = cJSON_GetObjectItemCaseSensitive(json, field_name);
+    if (cJSON_IsString(job_id) && (job_id->valuestring != NULL)) {
+        strncpy(dest, job_id->valuestring, max_size);
+        rv = true;
+    }
+    return rv;
+}
+
+
+bool parse_JSON_reply(WQC *handler, cJSON **reply_json)
+{
+    bool rv = true;
+
+    *reply_json = cJSON_Parse(handler->curl_info.web_reply.reply);
+
+    if (*reply_json == NULL) {
+
+        rv = false;
+        char position_str[12] = "no position";
+        const char *extra_messages[] =
+                {
+                        "Error parsing JSON reply: Error before",
+                        "(no location)",
+                        " at offset " ,
+                        position_str,
+                        NULL
+                };
+        const char *error_ptr = cJSON_GetErrorPtr();
+
+        if (error_ptr != NULL)
+        {
+            extra_messages[1] = error_ptr;
+            snprintf(position_str, sizeof position_str, "%lu", error_ptr - handler->curl_info.web_reply.reply);
+        }
+        wqc_set_error_with_messages(handler, WEBQC_WEB_CALL_ERROR, extra_messages);
+    }
+    return rv;
+}
+
+static bool get_string_field_from_reply(WQC *handler, const char *label, char *target, int target_len)
+{
+    bool rv = false;
+
+    cJSON *reply_json = NULL;
+
+    rv = parse_JSON_reply(handler, &reply_json);
+
+    if ( rv ) {
+        rv = get_string_from_reply(reply_json, label, target, target_len);
+        cJSON_Delete(reply_json);
+    }
+
+    return rv;
+}
+
+bool get_job_id_from_reply(WQC *handler)
+{
+    return get_string_field_from_reply(handler, "job_id", handler->job_id, WQC_JOB_ID_LENGTH);
+}
+
+bool get_parameter_set_id_from_reply(WQC *handler)
+{
+    return get_string_field_from_reply(handler, "set_id", handler->parameter_set_id, WQC_PARAM_SET_ID_LENGTH);
+}
+
+

--- a/src/web_access.c
+++ b/src/web_access.c
@@ -256,6 +256,7 @@ bool set_eri_job_parameters(WQC *handler, const struct two_electron_integrals_jo
 {
     bool rv = false;
 
+
     struct name_value_pair two_e_parameters_pairs[] = {
             {"basis_set_name",   WQC_STRING_TYPE, { .str_value=job_parameters->basis_set_name} },
             {"xyz_file_content", WQC_STRING_TYPE, { .str_value=job_parameters->geometry} }, // ADD IT TO PYTHON!!

--- a/src/webqc-errors.c
+++ b/src/webqc-errors.c
@@ -64,6 +64,16 @@ bool wqc_get_last_error(WQC *handler, struct wqc_return_value *error_structure)
     return res;
 }
 
+void wqc_set_error_with_message(WQC *handler, error_code_t code, const char *extra_message)
+{
+    wqc_set_error(handler, code);
+
+    int bytes_left = MAX_WEBQC_ERROR_MESSAGE_LEN - strlen(handler->return_value.error_message);
+
+    strncat(handler->return_value.error_message, ": ", 3);
+    strncat(handler->return_value.error_message, extra_message, bytes_left - 2);
+}
+
 void wqc_set_error_with_messages(WQC *handler, error_code_t code, const char *extra_messages[])
 {
     int i = 0;

--- a/test/test-eri.cpp
+++ b/test/test-eri.cpp
@@ -1,5 +1,7 @@
 #include <libwebqc.h>
 #include <catch2/catch_test_macros.hpp>
+#include "include/webqc-json.h"
+#include "include/webqc-handler.h"
 
 static const char *water_xyz_geometry =
         "3\n"
@@ -17,8 +19,6 @@ TEST_CASE( "submit integrals job", "[eri]" ) {
     SECTION("Do REST Call") {
 
         REQUIRE(wqc_set_option(handler, WQC_OPTION_ACCESS_TOKEN, WQC_FREE_ACCESS_TOKEN) == true);
-
-
         CHECK(wqc_submit_job(handler, WQC_JOB_TWO_ELECTRONS_INTEGRALS, &parameters) == true);
     }
     wqc_cleanup(handler);
@@ -43,5 +43,40 @@ TEST_CASE( "submit nonexistent job type", "[eri]" ) {
     REQUIRE(handler != NULL);
 
     REQUIRE( wqc_submit_job(handler, (enum wqc_job_type)432432, nullptr ) == false ) ;
+    wqc_cleanup(handler);
+}
+
+
+TEST_CASE( "submit integrals job to bad server", "[eri]" ) {
+    WQC *handler = wqc_init();
+    REQUIRE(handler != NULL);
+
+    SECTION("Do REST Call") {
+
+        REQUIRE(wqc_set_option(handler, WQC_OPTION_SERVER_NAME, "nosuchserver.cam:8732") == true);
+        CHECK(wqc_submit_job(handler, WQC_JOB_TWO_ELECTRONS_INTEGRALS, &parameters) == false);
+    }
+    wqc_cleanup(handler);
+}
+
+TEST_CASE( "try to parse a bad reply", "[eri]" ) {
+    WQC *handler = wqc_init();
+    REQUIRE(handler != NULL);
+
+    SECTION("Parse reply") {
+        char illegal_JSON[] = "{ \"a\" : 7, g: 6.6}";
+        size_t total_size = sizeof(illegal_JSON);
+
+        CHECK(wqc_collect_downloaded_data(illegal_JSON, total_size, &handler->curl_info.web_reply) == total_size);
+
+        struct wqc_return_value error_structure = init_webqc_return_value();
+        cJSON *reply_json = NULL;
+
+        CHECK(parse_JSON_reply(handler, &reply_json) == false);
+        CHECK(wqc_get_last_error(handler, &error_structure) == true );
+        CHECK(error_structure.error_code != 0 );
+        CHECK(error_structure.error_message[0] != '\0');
+
+    }
     wqc_cleanup(handler);
 }

--- a/test/test-eri.cpp
+++ b/test/test-eri.cpp
@@ -42,6 +42,6 @@ TEST_CASE( "submit nonexistent job type", "[eri]" ) {
     WQC *handler = wqc_init();
     REQUIRE(handler != NULL);
 
-    REQUIRE( wqc_submit_job(handler, (enum wqc_job_type)432432, NULL ) == false ) ;
+    REQUIRE( wqc_submit_job(handler, (enum wqc_job_type)432432, nullptr ) == false ) ;
     wqc_cleanup(handler);
 }

--- a/test/test-eri.cpp
+++ b/test/test-eri.cpp
@@ -19,7 +19,7 @@ TEST_CASE( "submit integrals job", "[eri]" ) {
         REQUIRE(wqc_set_option(handler, WQC_OPTION_ACCESS_TOKEN, WQC_FREE_ACCESS_TOKEN) == true);
 
 
-        CHECK(wqc_submit_job(handler, TWO_ELECTRONS_INTEGRAL, &parameters) == true);
+        CHECK(wqc_submit_job(handler, WQC_JOB_TWO_ELECTRONS_INTEGRALS, &parameters) == true);
     }
     wqc_cleanup(handler);
 }
@@ -33,15 +33,15 @@ TEST_CASE( "submit integrals job no SSL", "[eri]" ) {
         REQUIRE(wqc_set_option(handler, WQC_OPTION_ACCESS_TOKEN, WQC_FREE_ACCESS_TOKEN) == true);
         REQUIRE(wqc_set_option(handler, WQC_OPTION_INSECURE_SSL, 1) == true);
 
-        CHECK(wqc_submit_job(handler, TWO_ELECTRONS_INTEGRAL, &parameters) == true);
+        CHECK(wqc_submit_job(handler, WQC_JOB_TWO_ELECTRONS_INTEGRALS, &parameters) == true);
     }
     wqc_cleanup(handler);
 }
 
-TEST_CASE( "submit nonexistant job ", "[eri]" ) {
+TEST_CASE( "submit nonexistent job type", "[eri]" ) {
     WQC *handler = wqc_init();
     REQUIRE(handler != NULL);
 
-    REQUIRE( wqc_submit_job(handler, (wqc_job_types_tag)432432, NULL ) == false ) ;
+    REQUIRE( wqc_submit_job(handler, (enum wqc_job_type)432432, NULL ) == false ) ;
     wqc_cleanup(handler);
 }

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -1,3 +1,4 @@
+#include <time.h>
 #include <libwebqc.h>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/reporters/catch_reporter_event_listener.hpp>
@@ -10,6 +11,7 @@ public:
 
     void testRunStarting(Catch::TestRunInfo const&) override {
         wqc_global_init();
+        srand(time(NULL));
     }
 
     void testRunEnded( Catch::TestRunStats const& testRunStats ) override {

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -8,7 +8,7 @@ class testRunListener : public Catch::EventListenerBase {
 public:
     using Catch::EventListenerBase::EventListenerBase;
 
-    virtual void testRunStarting(Catch::TestRunInfo const&) override {
+    void testRunStarting(Catch::TestRunInfo const&) override {
         wqc_global_init();
     }
 
@@ -32,7 +32,7 @@ TEST_CASE( "Retrieving an error", "[options]" ) {
     WQC *handler = wqc_init();
     REQUIRE(handler != NULL);
     REQUIRE(wqc_set_option(handler, (wqc_option_t)(5748349), "hello") == false );
-    struct wqc_return_value error_info;
+    struct wqc_return_value error_info = init_webqc_return_value();
     REQUIRE(wqc_get_last_error(handler, &error_info) == true);
     REQUIRE(error_info.error_code == WEBQC_ERROR_UNKNOWN_OPTION );
     REQUIRE(error_info.error_message[0] );
@@ -42,38 +42,36 @@ TEST_CASE( "Retrieving an error", "[options]" ) {
 
 TEST_CASE( "string values get and set", "[options]" ) {
     const char *sample_string = "hello";
-    unsigned int i = 0;
     WQC *handler = wqc_init();
     REQUIRE(handler != NULL);
 
     wqc_option_t string_options[] = {WQC_OPTION_ACCESS_TOKEN, WQC_OPTION_SERVER_NAME};
 
-    for ( i = 0 ; i < sizeof(string_options)/sizeof(wqc_option_t) ; ++i) {
-        REQUIRE(wqc_set_option(handler, string_options[i], sample_string) == true);
+    for (auto & string_option : string_options) {
+        REQUIRE(wqc_set_option(handler, string_option, sample_string) == true);
         const char *value = nullptr;
-        REQUIRE(wqc_get_option(handler, string_options[i], &value) == true);
+        REQUIRE(wqc_get_option(handler, string_option, &value) == true);
         REQUIRE(strcmp(value, sample_string) == 0);
     }
     wqc_cleanup(handler);
 }
 
 TEST_CASE( "bool values get and set", "[options]" ) {
-    unsigned int i = 0;
     WQC *handler = wqc_init();
     REQUIRE(handler != NULL);
 
     wqc_option_t string_options[] = {WQC_OPTION_INSECURE_SSL};
 
-    for ( i = 0 ; i < sizeof(string_options)/sizeof(wqc_option_t) ; ++i) {
+    for (auto & string_option : string_options) {
 
-        REQUIRE(wqc_set_option(handler, string_options[i], true) == true);
+        REQUIRE(wqc_set_option(handler, string_option, true) == true);
         int value = false;
-        REQUIRE(wqc_get_option(handler, string_options[i], &value) == true);
+        REQUIRE(wqc_get_option(handler, string_option, &value) == true);
         REQUIRE(value == true );
 
-        REQUIRE(wqc_set_option(handler, string_options[i], false) == true);
+        REQUIRE(wqc_set_option(handler, string_option, false) == true);
         value = true;
-        REQUIRE(wqc_get_option(handler, string_options[i], &value) == true);
+        REQUIRE(wqc_get_option(handler, string_option, &value) == true);
         REQUIRE(value == false );
 
     }

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -1,5 +1,24 @@
 #include <libwebqc.h>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+#include <catch2/interfaces/catch_interfaces_reporter.hpp>
+
+class testRunListener : public Catch::EventListenerBase {
+public:
+    using Catch::EventListenerBase::EventListenerBase;
+
+    virtual void testRunStarting(Catch::TestRunInfo const&) override {
+        wqc_global_init();
+    }
+
+    void testRunEnded( Catch::TestRunStats const& testRunStats ) override {
+        wqc_global_cleanup();
+    }
+
+};
+
+CATCH_REGISTER_LISTENER(testRunListener)
 
 TEST_CASE( "Unknown options get and set result in error", "[options]" ) {
     WQC *handler = wqc_init();


### PR DESCRIPTION
To create a job , first create an empty job; assign immutable parameter set to it; and then call a specific computation with those parameter sets. Prevent running multiple copies of identical jobs.