### PR TITLE
macos fixes on the `eri-results` branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,14 @@ find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIR})
 include_directories(${libwebqc_SOURCE_DIR} ${libwebqc_SOURCE_DIR}/include)
 
+find_package(cJSON REQUIRED)
+include_directories(${CJSON_INCLUDE_DIR})
+
 add_library(libwebqc SHARED src/libwebqc.c src/webqc-options.c src/webqc-errors.c src/web_access.c src/reply_parsers.c include/webqc-json.h src/info-reply-parser.c src/webqc-eri.c)
 
 target_compile_options(libwebqc PUBLIC ${COMPILE_FLAGS})
 target_link_options(libwebqc PUBLIC ${LINK_FLAGS})
-target_link_libraries(libwebqc ${CURL_LIBRARIES} -lcjson)
+target_link_libraries(libwebqc ${CURL_LIBRARIES} ${CJSON_LIBRARIES})
 
 add_executable(water-sto3g-integrals examples/water-sto3g-integrals.c)
 add_dependencies(water-sto3g-integrals libwebqc)

--- a/src/webqc-eri.c
+++ b/src/webqc-eri.c
@@ -1,6 +1,13 @@
 #include <string.h>
 #include <errno.h>
+
+#ifdef __APPLE__
+#include <malloc/malloc.h>
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
+
 #include "webqc-handler.h"
 #include "webqc-web-access.h"
 #include "webqc-json.h"


### PR DESCRIPTION
Everything compiles, but I'm getting this weird message:

```
...
Capturing coverage data from /Users/arthur/github/libwebqc/build/CMakeFiles/libwebqc.dir/src
Found LLVM gcov version 13.0.0, which emulates gcov version 4.2.0
Using intermediate gcov format
Scanning /Users/arthur/github/libwebqc/build/CMakeFiles/libwebqc.dir/src for .gcno files ...
Found 7 graph files in /Users/arthur/github/libwebqc/build/CMakeFiles/libwebqc.dir/src
Processing src/web_access.c.gcno
geninfo: WARNING: could not open 
geninfo: WARNING: some exclusion markers may be ignored
Processing src/webqc-eri.c.gcno
unexpected block number: 2 (in 0)
Invalid .gcno File!
geninfo: WARNING: GCOV did not produce any data for /Users/arthur/github/libwebqc/build/CMakeFiles/libwebqc.dir/src/webqc-eri.c.gcno
Processing src/webqc-options.c.gcno
geninfo: WARNING: could not open 
geninfo: WARNING: some exclusion markers may be ignored
Processing src/info-reply-parser.c.gcno
geninfo: WARNING: could not open 
geninfo: WARNING: some exclusion markers may be ignored
Processing src/libwebqc.c.gcno
geninfo: WARNING: could not open /Users/arthur/github/libwebqc/build/
geninfo: WARNING: some exclusion markers may be ignored
Processing src/reply_parsers.c.gcno
geninfo: WARNING: could not open 
geninfo: WARNING: some exclusion markers may be ignored
Processing src/webqc-errors.c.gcno
geninfo: WARNING: could not open 
geninfo: WARNING: some exclusion markers may be ignored
Finished .info-file creation
...
```

and it gets stuck here for a few minutes, then it finishes fine.