### PR TITLE
ERI packing

### DIFF
--- a/examples/water-sto3g-integrals.c
+++ b/examples/water-sto3g-integrals.c
@@ -77,9 +77,8 @@ main()
         // Make another call on the same handler, to get some ERI values
         wqc_reset(handler);
 
-        eri_shell_index_t eri_range_begin = {1, 1, 0, 3};
-        eri_shell_index_t eri_range_end = {3, 0, 2, 2};
-        res = wqc_fetch_ERI_values(handler, &eri_range_begin, &eri_range_end);
+        eri_shell_index_t eri_index = {1, 1, 0, 3};
+        res = wqc_fetch_ERI_values(handler, &eri_index);
 
         if (res) {
             // Print out the integrals received and their accuracy
@@ -92,20 +91,31 @@ main()
 
             res = wqc_get_eri_values(handler, &eri_values, &eri_precision);
             if (res) {
+                int dpos = 0;
 
                 for (; !wqc_indices_equal(&eri_shell_index, &eri_shell_range_end);
                        wqc_next_shell_index(handler, &eri_shell_index)
                     ) {
 
-                    printf("[ %u %u | %u %u ] = %.9e (error: %f )\n",
-                           eri_index[0], eri_index[1], eri_index[2], eri_index[3],
-                           eri_value, eri_precision);
+                    int shells_count[4];
+                    wqc_get_number_of_functions_in_shells(handler, eri_shell_index, shells_count , 4);
+
+                    for (int b1 = 0U; b1 < shells_count[0]; b1++) {
+                        for (int b2 = 0U; b2 < shells_count[1]; b2++) {
+                            for (int k1 = 0U; k1 < shells_count[2]; k1++) {
+                                for (int k2 = 0U; k2 < shells_count[3]; k2++) {
+                                    fprintf(stdout," %.9e\n", eri_values[dpos++]);
+                                }
+                            }
+                        }
+                    }
+
                 }
+
             } else {
                 struct wqc_return_value error;
                 wqc_get_last_error(handler, &error);
                 fprintf(stderr, "Error retrieving ERI values : %s", error.error_message);
-                break;
             }
         } else {
             struct wqc_return_value error;

--- a/include/webqc-handler.h
+++ b/include/webqc-handler.h
@@ -91,18 +91,14 @@ size_t wqc_set_downloaded_data
 
 
 
-//! Read ERI values from an open file. If you have a local file with ERI values, use this funcitons to embed them in the
+//! Read ERI values from an open file. If you have a local file with ERI values, use this function to embed them in the
 ///! handler.
 //! \param handler Handler to store the ERI values on
 //! \param fp File pointer,opened for read and positioned on the first ERI to read
-//! \param begin_shell_index index of the first shell in the file (not function - shell index )
-//! \param end_shell_index index of the end ( one after last) shell to read
 //! \return true on success, If not, false, and set error on the handler
 bool read_ERI_values_from_file(
         WQC *handler,
-        FILE *fp,
-        const int *begin_shell_index,
-        const int *end_shell_index
+        FILE *fp
 );
 
 

--- a/libwebqc.h
+++ b/libwebqc.h
@@ -79,6 +79,7 @@ struct ERI_item_status {
 struct ERI_values {
     eri_shell_index_t begin_eri_index; /// Index of first ERI value we have in RAM
     eri_shell_index_t end_eri_index; /// Index of end ERI (one after last) value we have in RAM
+    size_t eri_data_size; /// How much memory is used, in bytes, for storing the ERIs
     double *eri_values; /// The ERI values themselves, in C ordering
     double eri_precision; /// Precision of the ERIs in RAM
 };
@@ -94,7 +95,7 @@ struct ERI_information {
     struct basis_function_instance *basis_functions; /// All basis functions instances
     struct radial_function_info *basis_function_primitives; /// All the primitives involved in the system
     unsigned int *shell_to_function; /// Map shell index to function index
-    struct ERI_values eri_values; ///  ERI values fetched fromthe WQC server
+    struct ERI_values eri_values; ///  ERI values fetched from the WQC server
     unsigned int next_primitive; /// Next primitive to fill up
     unsigned int next_function; /// Next function to fill up
 };
@@ -289,16 +290,15 @@ wqc_print_integrals_details(
     FILE *fp
 );
 
-//! Fetch from the WQC server the [eri_range_begin, eri_range_end) range of ERI that were calculated using the handler.
+//! Fetch from the WQC server some range of ERI that were calculated using the handler, that was calculated for
+//! the functions at eri_index.
 //! \param handler A handler where a ERI calculation was submitted on
-//! \param eri_range_begin First ERI to fetch
-//! \param eri_range_end end of the ERI integrals to fetch
+//! \param eri_index the 4 centers for which to fetch the ERI
 //! \return true on success, false on failure and set up the error description in the handler
 bool
 wqc_fetch_ERI_values(
     WQC *handler,
-    const eri_shell_index_t *eri_range_begin,
-    const eri_shell_index_t *eri_range_end
+    const eri_shell_index_t *eri_index
 );
 
 
@@ -328,7 +328,9 @@ wqc_indices_equal(
 /// \param begin output - first shell index whose ERI are available to use
 /// \param end output - end shell index whose ERI are available to use
 //! \return false if there were now ERIs downloaded at all. Else, returns true.
-bool wqc_get_shell_set_range(WQC *handler, eri_shell_index_t *begin, eri_shell_index_t *end);
+bool wqc_get_shell_set_range(WQC *handler,
+     eri_shell_index_t *begin,
+     eri_shell_index_t *end);
 
 
 //! Get the values of the ERIs, after it was fetched from the WQC server
@@ -341,6 +343,20 @@ wqc_get_eri_values(
     WQC *handler,
     const double **eri_values,
     double *eri_precision
+);
+
+/// Get the number of functions that are in each of the n shell. For example, in a p shell there are 3. This shell indices
+/// are listen in the ERI information structure.
+/// \param handler Handler the ERI calculation was called on
+/// \param shells List of shell indices that you are interested in
+/// \param number_of_functions output - per each shell, how many functions
+/// \param n how many shells you are interested in getting information about
+/// \return true if the information was fetched from the WQC server and all shell sized found. False otherwise
+bool wqc_get_number_of_functions_in_shells(
+    WQC *handler,
+    const int *shells,
+    int *number_of_functions,
+    int n
 );
 
 #ifdef __cplusplus

--- a/libwebqc.h
+++ b/libwebqc.h
@@ -46,7 +46,7 @@ typedef struct webqc_handler_t WQC; ///< A handler to a WQC operation. When star
 
 typedef double wqc_location_t[3]; /// A 3D location in the system
 
-typedef int eri_index_t[4]; /// An index of an ERI
+typedef int eri_shell_index_t[4]; /// An index of an ERI
 
 
 /// List of all the possible calls to WecQC service
@@ -77,8 +77,8 @@ struct ERI_item_status {
 
 /// information about ERI values, and the values fetched from the server
 struct ERI_values {
-    eri_index_t begin_eri_index; /// Index of first ERI value we have in RAM
-    eri_index_t end_eri_index; /// Index of end ERI (one after last) value we have in RAM
+    eri_shell_index_t begin_eri_index; /// Index of first ERI value we have in RAM
+    eri_shell_index_t end_eri_index; /// Index of end ERI (one after last) value we have in RAM
     double *eri_values; /// The ERI values themselves, in C ordering
     double eri_precision; /// Precision of the ERIs in RAM
 };
@@ -297,19 +297,19 @@ wqc_print_integrals_details(
 bool
 wqc_fetch_ERI_values(
     WQC *handler,
-    const eri_index_t *eri_range_begin,
-    const eri_index_t *eri_range_end
+    const eri_shell_index_t *eri_range_begin,
+    const eri_shell_index_t *eri_range_end
 );
 
 
-//! When iterating over ERIs sequantialy, use this function to increment the ERI index to the next position.
+//! When iterating over shells sequentially, use this function to increment the shell index to the next position.
 //! \param handler Handler where a call to calculate ERIs was made on
 //! \param eri_index  in - Current index ; out - next index position
 //! \return true if the index reached is actually stored in the handler.
 bool
-wqc_next_eri_index(
+wqc_next_shell_index(
     WQC *handler,
-    eri_index_t *eri_index
+    eri_shell_index_t *eri_index
 );
 
 
@@ -318,22 +318,28 @@ wqc_next_eri_index(
 //! \param eri_index_b second index to compare
 //! \return true if the indices are equal.
 bool
-wqc_eri_indices_equal(
-    const eri_index_t *eri_index_a,
-    const eri_index_t *eri_index_b
+wqc_indices_equal(
+    const eri_shell_index_t *eri_index_a,
+    const eri_shell_index_t *eri_index_b
 );
 
-//! Get the value of an ERI, after it was fetched from the WQC server
+/// Get the begin position and end position of the ERI that were calculated and downloaded.
+/// \param handler Handler the ERI calculation was called on
+/// \param begin output - first shell index whose ERI are available to use
+/// \param end output - end shell index whose ERI are available to use
+//! \return false if there were now ERIs downloaded at all. Else, returns true.
+bool wqc_get_shell_set_range(WQC *handler, eri_shell_index_t *begin, eri_shell_index_t *end);
+
+
+//! Get the values of the ERIs, after it was fetched from the WQC server
 //! \param handler Handler the ERI calculation was called on
-//! \param eri_index which ERI to fetch , in chemist's notation [ij|kl]
-//! \param eri_value output - the value of the integral
+//! \param eri_value output - the values of the integrals - all possible orientations in each shell (see documentation)
 //! \param eri_precision output - the precision of the value returned
 //! \return true if the integral value exists in the handler and is returned. False otherwise, and error set the handler
 bool
-wqc_get_eri_value(
+wqc_get_eri_values(
     WQC *handler,
-    const eri_index_t *eri_index,
-    double *eri_value,
+    const double **eri_values,
     double *eri_precision
 );
 

--- a/src/reply_parsers.c
+++ b/src/reply_parsers.c
@@ -314,6 +314,10 @@ parse_eri_status_array(WQC *handler, cJSON *eri_items)
     bool rv = false;
     cJSON *iterator = NULL;
 
+    free(handler->eri_status);
+    handler->eri_status = NULL;
+    handler->ERI_items_count=0;
+
     cJSON_ArrayForEach(iterator, eri_items) {
         if (cJSON_IsObject(iterator)) {
             struct ERI_item_status status;

--- a/src/webqc-eri.c
+++ b/src/webqc-eri.c
@@ -153,10 +153,30 @@ bool wqc_next_shell_index(
 }
 
 
+bool wqc_get_number_of_functions_in_shells(WQC *handler, const int *shells, int *number_of_functions, int n)
+{
+    bool rv = true;
+
+    if ( handler->eri_info.eri_values.eri_values) {
+        int i;
+        for ( i = 0 ; i < n ; i ++ ) {
+            number_of_functions[i] = handler->eri_info.shell_to_function[shells[i]+1]  - handler->eri_info.shell_to_function[shells[i]] ;
+        }
+        rv = true;
+    }  else {
+        rv = false;
+        wqc_set_error_with_message(handler, WEBQC_NOT_FETCHED , "Reading ERI value that was not retrieved from the WQC server");
+    }
+
+    return rv;
+}
+
+
 bool
 wqc_get_eri_values(WQC *handler, const double **eri_values, double *eri_precision)
 {
     bool rv = false;
+
     if ( handler->eri_info.eri_values.eri_values) {
         *eri_precision = handler->eri_info.eri_values.eri_precision;
         *eri_values = handler->eri_info.eri_values.eri_values;
@@ -168,30 +188,27 @@ wqc_get_eri_values(WQC *handler, const double **eri_values, double *eri_precisio
     return rv;
 }
 
-
-static void
-func_index_to_shell_index(WQC *handler, const eri_shell_index_t *func_range, unsigned int *shell_index)
+bool
+wqc_get_shell_set_range(WQC *handler, eri_shell_index_t *begin, eri_shell_index_t *end)
 {
-    for ( unsigned int i = 0U ; i < 4 ; ++i ) {
-        if ((*func_range)[i] == handler->eri_info.number_of_functions) {
-            shell_index[i] = handler->eri_info.number_of_shells;
-        } else {
-            shell_index[i] = handler->eri_info.basis_functions[(*func_range)[i]].shell_index;
-        }
+    bool res = false;
+    if ( handler->eri_info.eri_values.eri_values ) {
+        memcpy(begin, handler->eri_info.eri_values.begin_eri_index, sizeof(eri_shell_index_t));
+        memcpy(end, handler->eri_info.eri_values.end_eri_index, sizeof(eri_shell_index_t));
+        res = true;
     }
+    return res;
 }
 
 static bool
-make_ERI_request_URI_parameters(WQC *handler, unsigned int *shell_range_begin,
-                                unsigned int *shell_range_end)
+make_ERI_request_URI_parameters(WQC *handler, const eri_shell_index_t *shell_range)
 {
     bool rv = false;
     char URL_with_options[MAX_URL_SIZE];
 
-    if (snprintf(URL_with_options, MAX_URL_SIZE, "%s?%s=%s&%s=%u_%u_%u_%u&%s=%u_%u_%u_%u", handler->web_call_info.full_URL,
+    if (snprintf(URL_with_options, MAX_URL_SIZE, "%s?%s=%s&%s=%u_%u_%u_%u", handler->web_call_info.full_URL,
                  "set_id", handler->parameter_set_id,
-                 "begin", shell_range_begin[0], shell_range_begin[1], shell_range_begin[2], shell_range_begin[3],
-                 "end",  shell_range_end[0], shell_range_end[1], shell_range_end[2], shell_range_end[3]
+                 "begin", (*shell_range)[0], (*shell_range)[1], (*shell_range)[2], (*shell_range)[3]
     ) < MAX_URL_SIZE) {
         strncpy(handler
         ->web_call_info.full_URL, URL_with_options, MAX_URL_SIZE);
@@ -203,20 +220,15 @@ make_ERI_request_URI_parameters(WQC *handler, unsigned int *shell_range_begin,
 }
 
 bool
-wqc_fetch_ERI_values(WQC *handler, const eri_shell_index_t *eri_range_begin, const eri_shell_index_t *eri_range_end)
+wqc_fetch_ERI_values(WQC *handler, const eri_shell_index_t *shell_index)
 {
     bool rv = false;
 
     rv = prepare_web_call(handler, "eri_values");
 
     if ( rv ) {
-        unsigned int shell_range_begin[4];
-        unsigned int shell_range_end[4];
 
-        func_index_to_shell_index(handler, eri_range_begin, shell_range_begin);
-        func_index_to_shell_index(handler, eri_range_end, shell_range_end);
-
-        rv = make_ERI_request_URI_parameters(handler, shell_range_begin, shell_range_end );
+        rv = make_ERI_request_URI_parameters(handler, shell_index );
 
         if (! rv ) {
             wqc_set_error(handler, WEBQC_OUT_OF_MEMORY); // LCOV_EXCL_LINE
@@ -234,26 +246,14 @@ wqc_fetch_ERI_values(WQC *handler, const eri_shell_index_t *eri_range_begin, con
     return rv;
 }
 
-static void shell_index_to_eri_index(WQC *handler, const int *shell_index, eri_shell_index_t *eri_index)
-{
-    for ( int i = 0 ; i < 4 ; i++ ) {
-        (*eri_index)[i] = handler->eri_info.shell_to_function[shell_index[i]];
-    }
-}
 
-static bool allocate_memory_for_ERIs(WQC *handler, const int *begin_shell_index, const int *end_shell_index, int *no_of_values)
+static bool allocate_memory_for_ERIs(WQC *handler)
 {
     bool rv = true;
-    shell_index_to_eri_index(handler, begin_shell_index, &handler->eri_info.eri_values.begin_eri_index);
-    shell_index_to_eri_index(handler, end_shell_index, &handler->eri_info.eri_values.end_eri_index);
-
-    unsigned int first_available_function = eri_index_to_memory_position(handler, &handler->eri_info.eri_values.begin_eri_index);
-    unsigned int end_available_function = eri_index_to_memory_position(handler, &handler->eri_info.eri_values.end_eri_index);
-    *no_of_values = end_available_function - first_available_function;
 
     free(handler->eri_info.eri_values.eri_values);
 
-    handler->eri_info.eri_values.eri_values = malloc (sizeof(double) * (*no_of_values));
+    handler->eri_info.eri_values.eri_values = malloc (handler->eri_info.eri_values.eri_data_size);
 
     if ( ! handler->eri_info.eri_values.eri_values ) {
         wqc_set_error_with_message(handler, WEBQC_OUT_OF_MEMORY, "Not enough memory to read ERI values"); //LCOV_EXCL_LINE
@@ -263,10 +263,11 @@ static bool allocate_memory_for_ERIs(WQC *handler, const int *begin_shell_index,
     return rv;
 }
 
-bool read_ERI_values_from_file(WQC *handler, FILE *fp, const int *begin_shell_index, const int *end_shell_index)
+bool read_ERI_values_from_file(WQC *handler, FILE *fp)
 {
-    int no_of_values = 0;
-    bool rv = allocate_memory_for_ERIs(handler, begin_shell_index, end_shell_index, &no_of_values);
+    int no_of_values = handler->eri_info.eri_values.eri_data_size/(sizeof (double));
+
+    bool rv = allocate_memory_for_ERIs(handler);
 
     if ( rv ) {
         if (fread(handler->eri_info.eri_values.eri_values, sizeof(double), no_of_values, fp) != no_of_values) {
@@ -278,7 +279,7 @@ bool read_ERI_values_from_file(WQC *handler, FILE *fp, const int *begin_shell_in
 }
 
 
-static bool download_ERI_values(WQC *handler, const char *URL, const int *begin_shell_index, const int *end_shell_index)
+static bool download_ERI_values(WQC *handler, const char *URL)
 {
     bool rv = false;
     FILE *fp = tmpfile();
@@ -293,7 +294,7 @@ static bool download_ERI_values(WQC *handler, const char *URL, const int *begin_
                 const char * messages[] = { "Cannot rewind temporary ERI values file" , strerror(errno), NULL}; // LCOV_EXCL_LINE
                 wqc_set_error_with_messages(handler, WEBQC_IO_ERROR, messages);// LCOV_EXCL_LINE
             } else {
-                rv = read_ERI_values_from_file(handler, fp, begin_shell_index, end_shell_index);
+                rv = read_ERI_values_from_file(handler, fp);
             }
         }
         fclose(fp);
@@ -319,24 +320,23 @@ bool update_eri_values(WQC *handler)
             {"begin",        WQC_JSON_ARRAY,  &begin_info},
             {"end",          WQC_JSON_ARRAY,  &end_info},
             {"precision",    WQC_JSON_NUMBER, &handler->eri_info.eri_values.eri_precision},
+            {"size",    WQC_JSON_INT, &handler->eri_info.eri_values.eri_data_size},
             {NULL}
         };
 
         rv = extract_json_fields(handler, reply_json, fields);
     }
 
-    int begin_shell_index[4];
-    int end_shell_index[4];
     if (rv) {
-        rv = parse_int_array(handler, begin_info, begin_shell_index, 4);
+        rv = parse_int_array(handler, begin_info, handler->eri_info.eri_values.begin_eri_index, 4);
     }
 
     if ( rv ) {
-        rv = parse_int_array(handler, end_info, end_shell_index , 4);
+        rv = parse_int_array(handler, end_info, handler->eri_info.eri_values.end_eri_index , 4);
     }
 
     if ( rv ) {
-        rv = download_ERI_values(handler, ERI_URL, begin_shell_index, end_shell_index);
+        rv = download_ERI_values(handler, ERI_URL);
     }
 
     if ( reply_json ) {

--- a/test/test-eri.cpp
+++ b/test/test-eri.cpp
@@ -124,13 +124,13 @@ TEST_CASE( "submit integrals job and wait for it to finish", "[eri]" ) {
         CHECK(wqc_get_integrals_details(handler) == true);
         wqc_print_integrals_details(handler, stdout);
         wqc_reset(handler);
-        eri_index_t eri_range_begin = { 1,1,0,3 };
-        eri_index_t eri_range_end = { 7,0,0,0 };
+        eri_shell_index_t eri_range_begin = {1, 1, 0, 3 };
+        eri_shell_index_t eri_range_end = {7, 0, 0, 0 };
         CHECK(wqc_fetch_ERI_values(handler, &eri_range_begin, &eri_range_end) == true );
         double eri_value = 0;
         double eri_precision = WQC_PRECISION_UNKNOWN;
 
-        eri_index_t out_of_range_eri_index = { 7,0,0,0};
+        eri_shell_index_t out_of_range_eri_index = {7, 0, 0, 0};
         CHECK(wqc_get_eri_value(handler, &out_of_range_eri_index, &eri_value, &eri_precision) == false);
 
         struct wqc_return_value error_structure = init_webqc_return_value();
@@ -139,8 +139,8 @@ TEST_CASE( "submit integrals job and wait for it to finish", "[eri]" ) {
         CHECK(error_structure.error_message[0] != '\0');
 
         for (
-            eri_index_t eri_index = { eri_range_begin[0], eri_range_begin[1], eri_range_begin[2], eri_range_begin[3]} ;
-            ! wqc_eri_indices_equal(&eri_index, &eri_range_end)  ;
+            eri_shell_index_t eri_index = {eri_range_begin[0], eri_range_begin[1], eri_range_begin[2], eri_range_begin[3]} ;
+            !wqc_indices_equal(&eri_index, &eri_range_end)  ;
             wqc_next_eri_index(handler, &eri_index)
             ) {
 


### PR DESCRIPTION
ERI packing was wrong. It is actially not possible to create slices of the n^4 ERI values matrix using function indices. It is only possible using shell indices, as she integration library can produce ERI values for functions combination outside the given slice. So we slice now bu shell, not by function.